### PR TITLE
Makefile: build bootscript as part of os build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,8 @@ endif
 all: firmware os
 
 .PHONY: firmware os
-firmware: u-boot-signed ppa-optee bootscript
-os: linux rfs
+firmware: u-boot-signed ppa-optee
+os: linux rfs bootscript
 
 .PHONY: u-boot-signed
 u-boot-signed: u-boot $(O)/hdr_spl.out

--- a/Readme.md
+++ b/Readme.md
@@ -81,8 +81,6 @@ This will build the following items:
    * `build/hdr_spl.out`
  * OP-TEE OS and PPA
    * `build/ppa.itb`
- * Boot script
-   * `build/grapeboard_boot.scr`
 
 These files must be written to NOR flash.
 


### PR DESCRIPTION
Build bootscript as part of 'os' target and clarify Readme.